### PR TITLE
First task

### DIFF
--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -44,6 +44,18 @@ workflow minidata_test_alignment {
   output {
     File alignedBamSorted = BwaMem.analysisReadySorted
   }
+
+  parameter_meta {
+    sampleFastq: "Filepath to sample .fastq"
+    ref_fasta: "Filepath to reference genome"
+    ref_fasta_index: "Filepath to reference genome index"
+    ref_dict: "Filepath to reference genome dictionary"
+    ref_amb: "Filepath to reference genome info"
+    ref_ann: "Filepath to reference genome info"
+    ref_bwt: "Filepath to reference genome info"
+    ref_pac: "Filepath to reference genome info"
+    ref_sa: "Filepath to reference genome info"
+  }
 # End workflow
 }
 

--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -96,5 +96,6 @@ task BwaMem {
     memory: "48 GB"
     cpu: 16
     docker: "fredhutch/bwa:0.7.17"
+    disks: "local-disk 100 SSD"
   }
 }

--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -4,7 +4,7 @@ version 1.0
 ## NCIH2172_LUNG : Cell-line with EGFR L858R mutation
 ##
 ## Input requirements:
-## - fastq files for reference and alternative]
+## - fastq files for reference and alternative
 ##
 ## Output Files:
 ## - An aligned bam for 1 sample
@@ -15,44 +15,19 @@ workflow minidata_test_alignment {
   input {
     # Sample info
     File sampleFastq
-    String base_file_name
     # Reference Genome information
-    String ref_name
     File ref_fasta
     File ref_fasta_index
     File ref_dict
-    # This is the .alt file from bwa-kit (https://github.com/lh3/bwa/tree/master/bwakit),
-    # listing the reference contigs that are "alternative". Leave blank in JSON for legacy
-    # references such as b37 and hg19.
-    File? ref_alt
-    File ref_amb
-    File ref_ann
-    File ref_bwt
-    File ref_pac
-    File ref_sa
   }
-
-    # Docker containers this workflow has been designed for
-    String bwadocker = "fredhutch/bwa:0.7.17"
-    String GATKdocker = "broadinstitute/gatk:4.1.4.0"
-    
-    #Array[Object] batchInfo = read_objects(batchFile)
 
   #  Map reads to reference
   call BwaMem {
     input:
       input_fastq = sampleFastq,
-      base_file_name = base_file_name,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,
-      ref_dict = ref_dict,
-      ref_alt = ref_alt,
-      ref_amb = ref_amb,
-      ref_ann = ref_ann,
-      ref_bwt = ref_bwt,
-      ref_pac = ref_pac,
-      ref_sa = ref_sa,
-      taskDocker = bwadocker
+      ref_dict = ref_dict
   }
    
   # Outputs that will be retained when execution is complete
@@ -68,18 +43,13 @@ workflow minidata_test_alignment {
 task BwaMem {
   input {
     File input_fastq
-    String base_file_name
     File ref_fasta
     File ref_fasta_index
     File ref_dict
-    File? ref_alt
-    File ref_amb
-    File ref_ann
-    File ref_bwt
-    File ref_pac
-    File ref_sa
-    String taskDocker
   }
+  
+  String base_file_name = basename(input_fastq, ".fastq")
+
   # CL added some fake read groups for MarkDuplicates to run. 
   command <<<
     set -eo pipefail
@@ -94,12 +64,10 @@ task BwaMem {
   output {
     File analysisReadyBam = "~{base_file_name}.aligned.bam"
     File analysisReadySorted = "~{base_file_name}.sorted_query_aligned.bam"
-    
   }
   runtime {
     memory: "48 GB"
     cpu: 16
-    docker: taskDocker
-    walltime: "2:00:00"
+    docker: "fredhutch/bwa:0.7.17"
   }
 }

--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -19,6 +19,11 @@ workflow minidata_test_alignment {
     File ref_fasta
     File ref_fasta_index
     File ref_dict
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
   }
 
   #  Map reads to reference
@@ -27,7 +32,12 @@ workflow minidata_test_alignment {
       input_fastq = sampleFastq,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,
-      ref_dict = ref_dict
+      ref_dict = ref_dict,
+      ref_amb = ref_amb,
+      ref_ann = ref_ann,
+      ref_bwt = ref_bwt,
+      ref_pac = ref_pac,
+      ref_sa = ref_sa
   }
    
   # Outputs that will be retained when execution is complete
@@ -46,6 +56,11 @@ task BwaMem {
     File ref_fasta
     File ref_fasta_index
     File ref_dict
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
   }
   
   String base_file_name = basename(input_fastq, ".fastq")

--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -1,0 +1,105 @@
+version 1.0
+## Testing if alignement for 1 sample will work
+## Samples:
+## NCIH2172_LUNG : Cell-line with EGFR L858R mutation
+##
+## Input requirements:
+## - fastq files for reference and alternative]
+##
+## Output Files:
+## - An aligned bam for 1 sample
+## 
+## Workflow developed by Sitapriya Moorthi @ Fred Hutch LMD: 11/22/23 for use by DaSL @ Fred Hutch.
+
+workflow minidata_test_alignment {
+  input {
+    # Sample info
+    File sampleFastq
+    String base_file_name
+    # Reference Genome information
+    String ref_name
+    File ref_fasta
+    File ref_fasta_index
+    File ref_dict
+    # This is the .alt file from bwa-kit (https://github.com/lh3/bwa/tree/master/bwakit),
+    # listing the reference contigs that are "alternative". Leave blank in JSON for legacy
+    # references such as b37 and hg19.
+    File? ref_alt
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
+  }
+
+    # Docker containers this workflow has been designed for
+    String bwadocker = "fredhutch/bwa:0.7.17"
+    String GATKdocker = "broadinstitute/gatk:4.1.4.0"
+    
+    #Array[Object] batchInfo = read_objects(batchFile)
+
+  #  Map reads to reference
+  call BwaMem {
+    input:
+      input_fastq = sampleFastq,
+      base_file_name = base_file_name,
+      ref_fasta = ref_fasta,
+      ref_fasta_index = ref_fasta_index,
+      ref_dict = ref_dict,
+      ref_alt = ref_alt,
+      ref_amb = ref_amb,
+      ref_ann = ref_ann,
+      ref_bwt = ref_bwt,
+      ref_pac = ref_pac,
+      ref_sa = ref_sa,
+      taskDocker = bwadocker
+  }
+   
+  # Outputs that will be retained when execution is complete
+  output {
+    File alignedBamSorted = BwaMem.analysisReadySorted
+  }
+# End workflow
+}
+
+#### TASK DEFINITIONS
+# align to genome
+## Currently uses -M but GATK uses -Y and no -M
+task BwaMem {
+  input {
+    File input_fastq
+    String base_file_name
+    File ref_fasta
+    File ref_fasta_index
+    File ref_dict
+    File? ref_alt
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
+    String taskDocker
+  }
+  # CL added some fake read groups for MarkDuplicates to run. 
+  command <<<
+    set -eo pipefail
+
+    bwa mem \
+      -p -v 3 -t 16 -M -R '@RG\tID:foo\tSM:foo2' \
+      ~{ref_fasta} ~{input_fastq} > ~{base_file_name}.sam 
+    samtools view -1bS -@ 15 -o ~{base_file_name}.aligned.bam ~{base_file_name}.sam
+    samtools sort -n -@ 15 -o ~{base_file_name}.sorted_query_aligned.bam ~{base_file_name}.aligned.bam
+
+  >>>
+  output {
+    File analysisReadyBam = "~{base_file_name}.aligned.bam"
+    File analysisReadySorted = "~{base_file_name}.sorted_query_aligned.bam"
+    
+  }
+  runtime {
+    memory: "48 GB"
+    cpu: 16
+    docker: taskDocker
+    walltime: "2:00:00"
+  }
+}

--- a/WWW/1_first_task.wdl
+++ b/WWW/1_first_task.wdl
@@ -76,14 +76,24 @@ task BwaMem {
   }
   
   String base_file_name = basename(input_fastq, ".fastq")
+  String ref_fasta_local = basename(ref_fasta)
 
   # CL added some fake read groups for MarkDuplicates to run. 
   command <<<
     set -eo pipefail
 
+    mv ~{ref_fasta} .
+    mv ~{ref_fasta_index} .
+    mv ~{ref_dict} .
+    mv ~{ref_amb} .
+    mv ~{ref_ann} .
+    mv ~{ref_bwt} .
+    mv ~{ref_pac} .
+    mv ~{ref_sa} .
+
     bwa mem \
       -p -v 3 -t 16 -M -R '@RG\tID:foo\tSM:foo2' \
-      ~{ref_fasta} ~{input_fastq} > ~{base_file_name}.sam 
+      ~{ref_fasta_local} ~{input_fastq} > ~{base_file_name}.sam 
     samtools view -1bS -@ 15 -o ~{base_file_name}.aligned.bam ~{base_file_name}.sam
     samtools sort -n -@ 15 -o ~{base_file_name}.sorted_query_aligned.bam ~{base_file_name}.aligned.bam
 

--- a/WWW/2_linear_chain.wdl
+++ b/WWW/2_linear_chain.wdl
@@ -51,6 +51,18 @@ workflow minidata_test_alignment {
     File alignedBamSorted = BwaMem.analysisReadySorted
     File markDuplicates = MarkDuplicatesSpark.output_bam
   }
+
+  parameter_meta {
+    sampleFastq: "Filepath to sample .fastq"
+    ref_fasta: "Filepath to reference genome"
+    ref_fasta_index: "Filepath to reference genome index"
+    ref_dict: "Filepath to reference genome dictionary"
+    ref_amb: "Filepath to reference genome info"
+    ref_ann: "Filepath to reference genome info"
+    ref_bwt: "Filepath to reference genome info"
+    ref_pac: "Filepath to reference genome info"
+    ref_sa: "Filepath to reference genome info"
+  }
 # End workflow
 }
 

--- a/WWW/2_linear_chain.wdl
+++ b/WWW/2_linear_chain.wdl
@@ -81,16 +81,26 @@ task BwaMem {
     File ref_pac
     File ref_sa
   }
-
+  
   String base_file_name = basename(input_fastq, ".fastq")
+  String ref_fasta_local = basename(ref_fasta)
 
   # CL added some fake read groups for MarkDuplicates to run. 
   command <<<
     set -eo pipefail
 
+    mv ~{ref_fasta} .
+    mv ~{ref_fasta_index} .
+    mv ~{ref_dict} .
+    mv ~{ref_amb} .
+    mv ~{ref_ann} .
+    mv ~{ref_bwt} .
+    mv ~{ref_pac} .
+    mv ~{ref_sa} .
+
     bwa mem \
       -p -v 3 -t 16 -M -R '@RG\tID:foo\tSM:foo2' \
-      ~{ref_fasta} ~{input_fastq} > ~{base_file_name}.sam 
+      ~{ref_fasta_local} ~{input_fastq} > ~{base_file_name}.sam 
     samtools view -1bS -@ 15 -o ~{base_file_name}.aligned.bam ~{base_file_name}.sam
     samtools sort -n -@ 15 -o ~{base_file_name}.sorted_query_aligned.bam ~{base_file_name}.aligned.bam
 

--- a/WWW/2_linear_chain.wdl
+++ b/WWW/2_linear_chain.wdl
@@ -16,10 +16,14 @@ workflow minidata_test_alignment {
     # Sample info
     File sampleFastq
     # Reference Genome information
-    String ref_name
     File ref_fasta
     File ref_fasta_index
     File ref_dict
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
   }
 
   #  Map reads to reference
@@ -28,7 +32,12 @@ workflow minidata_test_alignment {
       input_fastq = sampleFastq,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,
-      ref_dict = ref_dict
+      ref_dict = ref_dict,
+      ref_amb = ref_amb,
+      ref_ann = ref_ann,
+      ref_bwt = ref_bwt,
+      ref_pac = ref_pac,
+      ref_sa = ref_sa
   }
    
   # Mark duplicates
@@ -54,6 +63,11 @@ task BwaMem {
     File ref_fasta
     File ref_fasta_index
     File ref_dict
+    File ref_amb
+    File ref_ann
+    File ref_bwt
+    File ref_pac
+    File ref_sa
   }
 
   String base_file_name = basename(input_fastq, ".fastq")
@@ -86,7 +100,7 @@ task MarkDuplicatesSpark {
   }
   
   String base_file_name = basename(input_bam, ".sorted_query_aligned.bam")
-  String output_bam = "~{base_file_name}.duplicates_marked"
+  String output_bam = "~{base_file_name}.duplicates_marked.bam"
   String metrics_file = "~{base_file_name}.duplicate_metrics"
 
   # Later use: --verbosity WARNING

--- a/WWW/2_linear_chain.wdl
+++ b/WWW/2_linear_chain.wdl
@@ -103,6 +103,7 @@ task BwaMem {
     memory: "48 GB"
     cpu: 16
     docker: "fredhutch/bwa:0.7.17"
+    disks: "local-disk 100 SSD"
   }
 }
 
@@ -131,6 +132,7 @@ task MarkDuplicatesSpark {
     docker: "broadinstitute/gatk:4.1.4.0"
     memory: "48 GB"
     cpu: 4
+    disks: "local-disk 100 SSD"
   }
   output {
     File output_bam = "~{output_bam}"

--- a/WWW/2_linear_chain.wdl
+++ b/WWW/2_linear_chain.wdl
@@ -123,7 +123,7 @@ task MarkDuplicatesSpark {
   }
   
   String base_file_name = basename(input_bam, ".sorted_query_aligned.bam")
-  String output_bam = "~{base_file_name}.duplicates_marked.bam"
+  String output_bam_string = "~{base_file_name}.duplicates_marked.bam"
   String metrics_file = "~{base_file_name}.duplicate_metrics"
 
   # Later use: --verbosity WARNING
@@ -134,7 +134,7 @@ task MarkDuplicatesSpark {
     gatk --java-options "-XX:+UseParallelGC -XX:ParallelGCThreads=4 -Dsamjdk.compression_level=5 -Xms32g" \
       MarkDuplicatesSpark \
       --input ~{input_bam} \
-      --output ~{output_bam} \
+      --output ~{output_bam_string} \
       --metrics-file ~{metrics_file} \
       --optical-duplicate-pixel-distance 2500 
   }
@@ -145,8 +145,8 @@ task MarkDuplicatesSpark {
     disks: "local-disk 100 SSD"
   }
   output {
-    File output_bam = "~{output_bam}"
-    File output_bai = "~{output_bam}.bai"
+    File output_bam = "~{output_bam_string}"
+    File output_bai = "~{output_bam_string}.bai"
     File duplicate_metrics = "~{metrics_file}"
   }
 }

--- a/WWW/minidata_batch.json
+++ b/WWW/minidata_batch.json
@@ -1,4 +1,4 @@
 {
   "minidata_test_alignment.base_file_name": "NA_12878_20k",
-  "minidata_test_alignment.sampleFastq": "/fh/scratch/delete90/_DaSL/clo2/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
+  "minidata_test_alignment.sampleFastq": "/fh/scratch/delete90/_DaSL/WDL-sandbox/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
 }

--- a/WWW/minidata_batch.json
+++ b/WWW/minidata_batch.json
@@ -1,4 +1,4 @@
 {
-  
-  "minidata_test_alignment.sampleFastq": "/fh/scratch/delete90/_DaSL/WDL_mini_data/NCIH2172_LUNG/SRR8618962_combined.fastq"
+  "minidata_test_alignment.base_file_name": "NA_12878_20k",
+  "minidata_test_alignment.sampleFastq": "/fh/scratch/delete90/_DaSL/clo2/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
 }

--- a/WWW/minidata_batch.json
+++ b/WWW/minidata_batch.json
@@ -1,4 +1,3 @@
 {
-  "minidata_test_alignment.base_file_name": "NA_12878_20k",
   "minidata_test_alignment.sampleFastq": "/fh/scratch/delete90/_DaSL/WDL-sandbox/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq"
 }

--- a/WWW/minidata_parameters_hg19json.json
+++ b/WWW/minidata_parameters_hg19json.json
@@ -1,5 +1,4 @@
 {
-  "minidata_test_alignment.ref_name": "hg19",
   "minidata_test_alignment.ref_fasta": "/fh/fast/paguirigan_a/pub/ReferenceDataSets/genome_data/human/hg19/Homo_sapiens_assembly19.fasta",
   "minidata_test_alignment.ref_fasta_index": "/fh/fast/paguirigan_a/pub/ReferenceDataSets/genome_data/human/hg19/Homo_sapiens_assembly19.fasta.fai",
   "minidata_test_alignment.ref_dict": "/fh/fast/paguirigan_a/pub/ReferenceDataSets/genome_data/human/hg19/Homo_sapiens_assembly19.dict",


### PR DESCRIPTION
Major changes:

- Split minidata_test.wdl into the steps we are going to write out in the guide: `1_first_task.wdl` and `2_linear_chain.wdl`.

- Fixed bugs in `2_linear_chain.wdl` so that both tasks will run in a linear chain. Fixes mostly relate to grabbing the output of the first task properly.

- I currently cannot access `/fh/scratch/delete90/_DaSL/WDL_mini_data`, so I am using some from  `/fh/scratch/delete90/_DaSL/WDL-sandbox` via GATK's[ NA12878 test data](https://console.cloud.google.com/storage/browser/_details/gatk-test-data/wgs_fastq/NA12878_20k/H06JUADXX130110.1.ATCACGAT.20k_interleaved.fastq;tab=live_object). This is reflected in the metadata json. 