### PR TITLE
Run miniwdl check upon PR

### DIFF
--- a/.github/workflows/miniwdl_check.yml
+++ b/.github/workflows/miniwdl_check.yml
@@ -1,0 +1,29 @@
+name: miniwdl_check
+
+on:
+  # Run when a PR targets main
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install miniwdl
+    - name: Analysing the code with miniwdl
+      run: |
+        miniwdl check $(git ls-files '*.wdl')

--- a/WWW/minidata_test.wdl
+++ b/WWW/minidata_test.wdl
@@ -63,7 +63,7 @@ workflow minidata_test_alignment {
    # Mark duplicates
   call MarkDuplicatesSpark as MarkDuplicates {
     input:
-      input_bam = ~{base_file_name} + "_sorted_query_aligned.bam",
+      input_bam = base_file_name + "_sorted_query_aligned.bam",
       output_bam_basename = base_file_name + ".aligned.duplicates_marked",
       metrics_filename = base_file_name + ".duplicate_metrics",
       taskDocker = GATKdocker


### PR DESCRIPTION
When a PR targets main, `miniwdl check` should run in GitHub actions. 

`miniwdl check` is a little easier to use and (arguably) more through than womtool, but it should be noted `miniwdl check` does not enforce `parameter_meta` sections. Once we add those sections, we should add womtool too.